### PR TITLE
Improve Google Description

### DIFF
--- a/democrasite/templates/base.html
+++ b/democrasite/templates/base.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}Democrasite{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A website which automatically merges changes based on popular approval">
+    <meta name="description" content="A website which automatically incorporates changes from users based on popular approval">
     <meta name="author" content="Matthew Foster Walsh">
     <meta name="google-site-verification" content="B7IAH2JHzzr3L40rxXcl-mITWAod6ud_1rOWTh-taHA" />
 

--- a/democrasite/templates/webiscite/bill_list.html
+++ b/democrasite/templates/webiscite/bill_list.html
@@ -34,7 +34,7 @@
               </p>
             {% endif %}
             <hr>
-            <div class="card-text">
+            <div data-nosnippet class="card-text">
               {{ bill.description|truncatewords:20 }}
             </div>
             <div class="card-text text-right">


### PR DESCRIPTION
Google pulled the site snippet from the first bill on the page, creating a strange and irrelevant description. This change would tell Google not to use Bill descriptions for its snippet as well as improve the meta description tag.