### PR TITLE
Don't console.log csrftoken

### DIFF
--- a/democrasite/static/js/note_interact.js
+++ b/democrasite/static/js/note_interact.js
@@ -2,7 +2,6 @@
 
 $(document).ready(function () {
   const csrftoken = $("[name=csrfmiddlewaretoken]")[0].value;
-  console.log(csrftoken);
   $(".note-like").click(function () {
     $.ajax($(this).attr("action"), {
       method: "POST",

--- a/democrasite/static/js/person_follow.js
+++ b/democrasite/static/js/person_follow.js
@@ -1,6 +1,5 @@
 $(document).ready(function () {
   const csrftoken = $("[name=csrfmiddlewaretoken]")[0].value;
-  console.log(csrftoken);
   $(".person-follow").click(function () {
     $.ajax($(this).attr("action"), {
       method: "POST",

--- a/democrasite/static/js/vote.js
+++ b/democrasite/static/js/vote.js
@@ -17,7 +17,6 @@ function update_progress(_, pbar) {
 
 $(document).ready(function () {
   const csrftoken = $("[name=csrfmiddlewaretoken]")[0].value;
-  console.log(csrftoken);
   $(".vote").click(function () {
     // Don't let users vote on expired bills
     if ($(this).parent().hasClass("inactive")) {


### PR DESCRIPTION
I was previously logging the csrf token to the console on every page that had an ajax request. I removed that (afaik it's not really a security risk but it's pointless in production).