### PR TITLE
Add "container" arg to just shell command

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,8 +48,8 @@ run +cmd:
 
 # Open a shell in the Django container
 [group("docker")]
-shell:
-    @docker compose run --rm django bash
+shell +container="django":
+    @docker compose run --rm {{ container }} bash
 
 # Executes `manage.py` command
 [group("management")]


### PR DESCRIPTION
The command "just shell" can be used to create a shell on one of the running docker containers when developing locally. Previously it only worked on the main server container, but now the container arg can be used to specify any of the containers by their service names.