### PR TITLE
Make bills link to visual diff on github

### DIFF
--- a/democrasite/templates/webiscite/bill_detail.html
+++ b/democrasite/templates/webiscite/bill_detail.html
@@ -29,7 +29,7 @@
           {% endif %}
           <br />
           <a class="link-underline link-underline-opacity-0"
-             href="{{ bill.pull_request.diff_url }}"
+             href="{{ bill.pull_request.diff_link }}"
              target="_blank">
             Diff:
             <span class="text-success">+{{ bill.pull_request.additions }}</span>

--- a/democrasite/templates/webiscite/bill_list.html
+++ b/democrasite/templates/webiscite/bill_list.html
@@ -31,7 +31,7 @@
             <div data-nosnippet class="card-text">{{ bill.description|truncatechars:80 }}</div>
             <div class="card-text text-start">
               <a class="card-link link-underline link-underline-opacity-0"
-                 href="{{ bill.pull_request.diff_url }}"
+                 href="{{ bill.pull_request.diff_link }}"
                  target="_blank">
                 <span class="text-success">+{{ bill.pull_request.additions }}</span>
                 <span class="text-danger">-{{ bill.pull_request.deletions }}</span>

--- a/democrasite/webiscite/fixtures/democrasite.json
+++ b/democrasite/webiscite/fixtures/democrasite.json
@@ -47,7 +47,7 @@
       "title": "The Initial Act",
       "additions": 0,
       "deletions": 0,
-      "diff_url": "https://github.com/mfosterw/cookiestocracy/pull/64/files",
+      "diff_url": "https://github.com/mfosterw/cookiestocracy/pull/64.diff",
       "author_name": "matthew",
       "sha": "123"
     }
@@ -63,7 +63,7 @@
       "title": "The Test Act",
       "additions": 1000,
       "deletions": 1000,
-      "diff_url": "https://github.com/mfosterw/cookiestocracy/pull/64/files",
+      "diff_url": "https://github.com/mfosterw/cookiestocracy/pull/64.diff",
       "author_name": "octocat",
       "sha": "1234"
     }
@@ -79,7 +79,7 @@
       "title": "The Finished Act",
       "additions": 69,
       "deletions": 420,
-      "diff_url": "https://github.com/mfosterw/cookiestocracy/pull/64/files",
+      "diff_url": "https://github.com/mfosterw/cookiestocracy/pull/64.diff",
       "author_name": "dependabot",
       "sha": "12345"
     }

--- a/democrasite/webiscite/models.py
+++ b/democrasite/webiscite/models.py
@@ -81,6 +81,11 @@ class PullRequest(StatusModel, TimeStampedModel):
     def __str__(self) -> str:
         return f"PR #{self.number}"
 
+    @property
+    def diff_link(self) -> str:
+        """Return base url of PR by removing ".diff" extension"""
+        return self.diff_url.rsplit(".", 1)[0] + "/files"
+
     def close(self) -> "Bill | None":
         """Mark the pull request and the associated bill closed if it was open
 


### PR DESCRIPTION
Apparently, for reasons I don't remember, I changed the diff links in the fixtures to point to the visual diff in github even though the automation depends on the url being the raw diff. It doesn't actually matter since obviously the fixtures can't be merged, but when someone tried to open the link on the website, they were shown the raw diff, which made no sense.