### PR TITLE
Made bill description preview 50% longer

### DIFF
--- a/democrasite/templates/webiscite/bill_list.html
+++ b/democrasite/templates/webiscite/bill_list.html
@@ -28,7 +28,7 @@
                         {% endif %}">{{ bill.get_status_display }}</p>
             {% endif %}
             <hr />
-            <div data-nosnippet class="card-text">{{ bill.description|truncatechars:80 }}</div>
+            <div data-nosnippet class="card-text">{{ bill.description|truncatechars:120 }}</div>
             <div class="card-text text-start">
               <a class="card-link link-underline link-underline-opacity-0"
                  href="{{ bill.pull_request.diff_url }}"


### PR DESCRIPTION
Increased the number of characters displayed of bill descriptions in the bill list page so that it's easier to understand the purpose of bills at a glance.