### PR TITLE
Redirect instead of 403 if user tries to create person twice

### DIFF
--- a/democrasite/activitypub/views.py
+++ b/democrasite/activitypub/views.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from django import http
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.core.exceptions import PermissionDenied
+from django.contrib.auth.views import redirect_to_login
 from django.http import HttpRequest
 from django.http import HttpResponseRedirect
 from django.http import JsonResponse
@@ -159,11 +159,15 @@ class PersonCreateView(CreateView):
     def post(self, request):
         """Ensure the user does not already have a Person profile."""
         if not self.request.user.is_authenticated:
-            raise PermissionDenied
+            messages.info(request, "You must be logged in to do that.")
+            return redirect_to_login(reverse("activitypub:note-list"))
         try:
             if self.request.user.person:
                 messages.info(request, "You already have an ActivityPub Profile!")
-                return redirect("activitypub:note-create")
+                return redirect(
+                    "activitypub:person-detail",
+                    username=request.user.person.display_name,
+                )
         except Person.DoesNotExist:
             pass
         return super().post(request)

--- a/democrasite/activitypub/views.py
+++ b/democrasite/activitypub/views.py
@@ -6,6 +6,7 @@ from django import http
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.views import redirect_to_login
+from django.contrib.messages.views import SuccessMessageMixin
 from django.http import HttpRequest
 from django.http import HttpResponseRedirect
 from django.http import JsonResponse
@@ -145,16 +146,13 @@ class PersonDetailView(DetailView):
 person_detail_view = PersonDetailView.as_view()
 
 
-class PersonCreateView(CreateView):
+class PersonCreateView(SuccessMessageMixin, CreateView):
     model = Person
     fields = []
 
-    def form_valid(self, form: "ModelForm[Person]"):
-        assert self.request.user.is_authenticated  # type guard
-        form.instance.user = self.request.user
-        form.instance.private_key = "private_key_placeholder"
-        form.instance.public_key = "public_key_placeholder"
-        return super().form_valid(form)
+    success_message = "Profile created successfully."
+
+    http_method_names = ["post"]
 
     def post(self, request):
         """Ensure the user does not already have a Person profile."""
@@ -171,6 +169,13 @@ class PersonCreateView(CreateView):
         except Person.DoesNotExist:
             pass
         return super().post(request)
+
+    def form_valid(self, form: "ModelForm[Person]"):
+        assert self.request.user.is_authenticated  # type guard
+        form.instance.user = self.request.user
+        form.instance.private_key = "private_key_placeholder"
+        form.instance.public_key = "public_key_placeholder"
+        return super().form_valid(form)
 
 
 person_create_view = PersonCreateView.as_view()


### PR DESCRIPTION
A single user cannot have multiple ActivityPub profiles but it is relatively easy to navigate back to a page with "Create Profile" on it after creating your profile. To reduce frustration and confusion this was changed from returning a Permission Denied error to just redirect the user to creating a note with a message describing acknowledging the redirect.