### PR TITLE
Added divider to navbar dropdown

### DIFF
--- a/democrasite/templates/base.html
+++ b/democrasite/templates/base.html
@@ -112,6 +112,7 @@
                   {% endif %}
                 {% endblock nav_authentication %}
               </ul>
+              <hr class="d-block d-md-none" />
               <ul class="navbar-nav">
                 <li class="nav-item">
                   <a href="{% url 'activitypub:note-list' %}" class="nav-link">{% trans 'ActivityPub' %}</a>


### PR DESCRIPTION
On desktop, the activitypub link (and api and admin in development) in the navbar are separated by the remaining width of the window. On mobile, the navbar is displayed as a dropdown which had no visual separation, so I added a dynamic divider which appears only on the dropdown.