### PR TITLE
Fix 404 page

### DIFF
--- a/democrasite/templates/404.html
+++ b/democrasite/templates/404.html
@@ -7,11 +7,5 @@
 {% endblock title %}
 {% block content %}
   <h1>{% trans 'Page not found' %}</h1>
-  <p>
-    {% if exception %}
-      {{ exception }}
-    {% else %}
-      {% trans 'This is not the page you were looking for.' %}
-    {% endif %}
-  </p>
+  <p>{% trans 'This page does not exist.' %}</p>
 {% endblock content %}


### PR DESCRIPTION
Inserting the error message into the 404 page turns out to be totally unhelpful, so it's just going to have a static message now.